### PR TITLE
Support single query socket

### DIFF
--- a/src/chroma_haystack/retriever.py
+++ b/src/chroma_haystack/retriever.py
@@ -9,9 +9,9 @@ from chroma_haystack import ChromaDocumentStore
 
 
 @component
-class ChromaDenseRetriever:
+class ChromaQueryRetriever:
     """
-    A component for retrieving documents from an ChromaDocumentStore.
+    A component for retrieving documents from an ChromaDocumentStore using the `query` API.
     """
 
     def __init__(self, document_store: ChromaDocumentStore, filters: Optional[Dict[str, Any]] = None, top_k: int = 10):
@@ -55,7 +55,25 @@ class ChromaDenseRetriever:
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "ChromaDenseRetriever":
+    def from_dict(cls, data: Dict[str, Any]) -> "ChromaQueryRetriever":
         document_store = ChromaDocumentStore.from_dict(data["init_parameters"]["document_store"])
         data["init_parameters"]["document_store"] = document_store
         return default_from_dict(cls, data)
+
+
+@component
+class ChromaSingleQueryRetriever(ChromaQueryRetriever):
+    """
+    A convenient wrapper to the standard query retriever that accepts a single query
+    and returns a list of documents
+    """
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        query: str,
+        filters: Optional[Dict[str, Any]] = None,  # filters not yet supported
+        top_k: Optional[int] = None,
+    ):
+        queries = [query]
+        return super().run(queries, filters, top_k)[0]

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,7 +1,7 @@
 import pytest
 
 from chroma_haystack.document_store import ChromaDocumentStore
-from chroma_haystack.retriever import ChromaDenseRetriever
+from chroma_haystack.retriever import ChromaQueryRetriever
 
 
 @pytest.mark.integration
@@ -9,9 +9,9 @@ def test_retriever_to_json(request):
     ds = ChromaDocumentStore(
         collection_name=request.node.name, embedding_function="HuggingFaceEmbeddingFunction", api_key="1234567890"
     )
-    retriever = ChromaDenseRetriever(ds, filters={"foo": "bar"}, top_k=99)
+    retriever = ChromaQueryRetriever(ds, filters={"foo": "bar"}, top_k=99)
     assert retriever.to_dict() == {
-        "type": "ChromaDenseRetriever",
+        "type": "ChromaQueryRetriever",
         "init_parameters": {
             "filters": {"foo": "bar"},
             "top_k": 99,
@@ -27,7 +27,7 @@ def test_retriever_to_json(request):
 @pytest.mark.integration
 def test_retriever_from_json(request):
     data = {
-        "type": "ChromaDenseRetriever",
+        "type": "ChromaQueryRetriever",
         "init_parameters": {
             "filters": {"bar": "baz"},
             "top_k": 42,
@@ -38,7 +38,7 @@ def test_retriever_from_json(request):
             },
         },
     }
-    retriever = ChromaDenseRetriever.from_dict(data)
+    retriever = ChromaQueryRetriever.from_dict(data)
     assert retriever.document_store._collection_name == request.node.name
     assert retriever.document_store._embedding_function == "HuggingFaceEmbeddingFunction"
     assert retriever.document_store._embedding_function_params == {"api_key": "1234567890"}


### PR DESCRIPTION
See #6 

The in-memory retriever in Haystack takes only a single query in input, while Chroma takes a list of queries. Since taking a list of queries is the way [Chroma API works](https://docs.trychroma.com/reference/Collection#query) I would keep this retriever as it is. 

Instead of changing the existing retriever, I added another one that takes a single query, as a way to simplify an Haystack pipeline built to support the in-memory retriever (`ChromaSingleQueryRetriever` would be swappable).

For clarity, I renamed the retrievers to `ChromaQueryRetriever` and `ChromaSingleQueryRetriever`.