### PR TITLE
Query passing embeddings

### DIFF
--- a/src/chroma_haystack/document_store.py
+++ b/src/chroma_haystack/document_store.py
@@ -186,6 +186,18 @@ class ChromaDocumentStore:
         )
         return self._query_result_to_documents(results)
 
+    def search_embeddings(self, query_embeddings: List[List[float]], top_k: int) -> List[List[Document]]:
+        """
+        Perform vector search on the stored document, pass the embeddings of the queries
+        instead of their text
+        """
+        results = self._collection.query(
+            query_embeddings=query_embeddings,
+            n_results=top_k,
+            include=["embeddings", "documents", "metadatas", "distances"],
+        )
+        return self._query_result_to_documents(results)
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ChromaDocumentStore":
         return ChromaDocumentStore(**data)

--- a/src/chroma_haystack/retriever.py
+++ b/src/chroma_haystack/retriever.py
@@ -77,3 +77,27 @@ class ChromaSingleQueryRetriever(ChromaQueryRetriever):
     ):
         queries = [query]
         return super().run(queries, filters, top_k)[0]
+
+
+@component
+class ChromaEmbeddingRetriever(ChromaQueryRetriever):
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        query_embedding: List[float],
+        _: Optional[Dict[str, Any]] = None,  # filters not yet supported
+        top_k: Optional[int] = None,
+    ):
+        """
+        Run the retriever on the given input data.
+
+        :param queries: The input data for the retriever. In this case, a list of queries.
+        :return: The retrieved documents.
+
+        :raises ValueError: If the specified document store is not found or is not a MemoryDocumentStore instance.
+        """
+        if not top_k:
+            top_k = 3
+
+        query_embeddings = [query_embedding]
+        return {"documents": self.document_store.search_embeddings(query_embeddings, top_k)[0]}


### PR DESCRIPTION
Add a new retriever that uses the `search` api in Chroma passing the embedding instead of the query text.